### PR TITLE
Handle 400 Bad Request from API

### DIFF
--- a/lib/sendgrid_toolkit/abstract_sendgrid_client.rb
+++ b/lib/sendgrid_toolkit/abstract_sendgrid_client.rb
@@ -1,27 +1,35 @@
 module SendgridToolkit
   class AbstractSendgridClient
-    
+
     def initialize(api_user = nil, api_key = nil)
       @api_user = (api_user.nil?) ? ENV['SMTP_USERNAME'] : api_user
       @api_key = (api_key.nil?) ? ENV['SMTP_PASSWORD'] : api_key
-      
+
       raise SendgridToolkit::NoAPIUserSpecified if @api_user.blank?
       raise SendgridToolkit::NoAPIKeySpecified if @api_key.blank?
     end
-    
+
     protected
-    
+
     def api_post(module_name, action_name, opts = {})
       response = HTTParty.post("https://#{BASE_URI}/#{module_name}.#{action_name}.json?", :query => get_credentials.merge(opts), :format => :json)
-      raise(SendgridToolkit::SendgridServerError, "The sengrid server returned an error. #{response.inspect}") if response.code > 401
-      raise SendgridToolkit::AuthenticationFailed if has_error?(response) && response['error'].has_key?('code') && response['error']['code'].to_i == 401
+      if response.code > 401
+        raise(SendgridToolkit::SendgridServerError, "The sengrid server returned an error. #{response.inspect}")
+      elsif has_error?(response) and
+          response['error'].respond_to?(:has_key?) and
+          response['error'].has_key?('code') and
+          response['error']['code'].to_i == 401
+        raise SendgridToolkit::AuthenticationFailed
+      elsif has_error?(response)
+        raise(SendgridToolkit::APIError, response['error'])
+      end
       response
     end
-    
+
     def get_credentials
       {:api_user => @api_user, :api_key => @api_key}
     end
-    
+
     private
     def has_error?(response)
       response.kind_of?(Hash) && response.has_key?('error')

--- a/lib/sendgrid_toolkit/sendgrid_error.rb
+++ b/lib/sendgrid_toolkit/sendgrid_error.rb
@@ -6,4 +6,5 @@ module SendgridToolkit
   class UnsubscribeEmailDoesNotExist < StandardError; end
   class EmailDoesNotExist < StandardError; end
   class SendgridServerError < StandardError; end
+  class APIError < StandardError; end
 end

--- a/spec/lib/sendgrid_toolkit/abstract_sendgrid_client_spec.rb
+++ b/spec/lib/sendgrid_toolkit/abstract_sendgrid_client_spec.rb
@@ -16,12 +16,19 @@ describe SendgridToolkit::AbstractSendgridClient do
         @obj.send(:api_post, "profile", "get", {})
       }.should raise_error SendgridToolkit::AuthenticationFailed
     end
-    it "thows error when sendgrid response is an error" do
+    it "thows error when sendgrid response is a server error" do
       FakeWeb.register_uri(:post, %r|https://sendgrid\.com/api/profile\.get\.json\?|, :body => 'A server error occured', :status => ['500', 'Internal Server Error'])
       @obj = SendgridToolkit::AbstractSendgridClient.new("someuser", "somepass")
       lambda {
         @obj.send(:api_post, "profile", "get", {})
       }.should raise_error SendgridToolkit::SendgridServerError
+    end
+    it "thows error when sendgrid response is an API error" do
+      FakeWeb.register_uri(:post, %r|https://sendgrid\.com/api/stats\.get\.json\?|, :body => '{"error": "error in end_date: end date is in the future"}', :status => ['400', 'Bad Request'])
+      @obj = SendgridToolkit::AbstractSendgridClient.new("someuser", "somepass")
+      lambda {
+        @obj.send(:api_post, "stats", "get", {})
+      }.should raise_error SendgridToolkit::APIError
     end
   end
 


### PR DESCRIPTION
At the moment if you call `stats.get` with an end date in the future, the SendGrid API returns `400 Bad Request`, with an error string instead of a hash. This causes the toolkit to crash like so:

```
NoMethodError: undefined method `has_key?' for "error in end_date: end date is in the future":String
    from sendgrid_toolkit-1.0.4/lib/sendgrid_toolkit/abstract_sendgrid_client.rb:17:in `api_post'
    from sendgrid_toolkit-1.0.4/lib/sendgrid_toolkit/statistics.rb:4:in `retrieve'
```

I just tweaked the error handling slightly to throw an `APIError` instead of accidentally throwing a `NoMethodError`.
