### PR TITLE
Fails if smtp environment var are not set

### DIFF
--- a/spec/lib/sendgrid_toolkit/common_spec.rb
+++ b/spec/lib/sendgrid_toolkit/common_spec.rb
@@ -6,7 +6,7 @@ describe SendgridToolkit::Common do
     class FakeClass < SendgridToolkit::AbstractSendgridClient
       include SendgridToolkit::Common
     end
-    @fake_class = FakeClass.new
+    @fake_class = FakeClass.new("fakeuser", "fakepass")
   end
 
   it "creates a module_name method that returns the class name downcased" do


### PR DESCRIPTION
Just cloned the repo and ran `rake`, noticed that `spec/lib/sendgrid_toolkit/common_spec.rb` was raising SendgridToolkit::NoAPIUserSpecified

This fix aims to ensure that the spec passes independently of having SMTP_USERNAME and SMTP_PASSWORD set.
