### PR TITLE
Allow a body to be posted

### DIFF
--- a/lib/sendgrid_toolkit/abstract_sendgrid_client.rb
+++ b/lib/sendgrid_toolkit/abstract_sendgrid_client.rb
@@ -11,8 +11,8 @@ module SendgridToolkit
 
     protected
 
-    def api_post(module_name, action_name, opts = {})
-      response = HTTParty.post("https://#{BASE_URI}/#{module_name}.#{action_name}.json?", :query => get_credentials.merge(opts), :format => :json)
+    def api_post(module_name, action_name, opts = {}, body = {})
+      response = HTTParty.post("https://#{BASE_URI}/#{module_name}.#{action_name}.json?", :query => get_credentials.merge(opts), :body => body, :format => :json)
       if response.code > 401
         raise(SendgridToolkit::SendgridServerError, "The sengrid server returned an error. #{response.inspect}")
       elsif has_error?(response) and

--- a/lib/sendgrid_toolkit/mail.rb
+++ b/lib/sendgrid_toolkit/mail.rb
@@ -1,7 +1,7 @@
 module SendgridToolkit
   class Mail < AbstractSendgridClient
-    def send_mail(options = {})
-      response = api_post('mail', 'send', options)
+    def send_mail(options = {}, body = {})
+      response = api_post('mail', 'send', options, body)
       raise(SendEmailError, "SendMail API refused to send email: #{response["errors"].inspect}") if response["message"] == "error"
       response
     end

--- a/spec/lib/sendgrid_toolkit/mail_spec.rb
+++ b/spec/lib/sendgrid_toolkit/mail_spec.rb
@@ -5,6 +5,8 @@ describe SendgridToolkit::Mail do
     FakeWeb.clean_registry
     @obj = SendgridToolkit::Mail.new("fakeuser", "fakepass")
   end
+
+  subject { SendgridToolkit::Mail.new("fakeuser", "fakepass") }
   
   describe "#send" do
     it "raises error when sendgrid returns an error" do
@@ -12,6 +14,18 @@ describe SendgridToolkit::Mail do
       lambda {
         response = @obj.send_mail :from => "testing@fiverr.com", :subject => "Subject", :text => "Text", "x-smtpapi" => {:category => "Testing", :to => ["elad@fiverr.com"]}
       }.should raise_error SendgridToolkit::SendEmailError
+    end
+    it 'accepts a post body' do
+      options = { :from => "testing@fiverr.com",
+        :subject => "Subject",
+        :text => "Text",
+        "x-smtpapi" => {:category => "Testing", :to => ["email@email.com"] }
+      }
+      body = {
+        :html => "<html><head></head><body>Test</body></html>"
+      }
+      subject.should_receive(:api_post).with('mail', 'send', options, body).and_return({})
+      subject.send_mail(options, body)
     end
   end  
 end


### PR DESCRIPTION
When sending mail through the api you must use a POST body if your uri becomes too large (due to a large message, long x-smtpapi headers, etc.). This allows users to use a POST body with the mail api method.

Closes #13