### PR TITLE
Changed the created attribute parsing to parse it as UTC

### DIFF
--- a/lib/sendgrid_toolkit/common.rb
+++ b/lib/sendgrid_toolkit/common.rb
@@ -35,7 +35,7 @@ module SendgridToolkit
     private
 
     def parse_message_time(message)
-      message['created'] = Time.parse(message['created']) if message.has_key?('created')
+      message['created'] = Time.parse(message['created']+' UTC') if message.has_key?('created')
     end
 
   end

--- a/lib/sendgrid_toolkit/unsubscribes.rb
+++ b/lib/sendgrid_toolkit/unsubscribes.rb
@@ -21,7 +21,7 @@ module SendgridToolkit
       options.merge! :date => 1
       response = retrieve options
       response.each do |unsubscribe|
-        unsubscribe['created'] = Time.parse(unsubscribe['created']) if unsubscribe.has_key?('created')
+        unsubscribe['created'] = Time.parse(unsubscribe['created']+' UTC') if unsubscribe.has_key?('created')
       end
       response
     end

--- a/spec/lib/sendgrid_toolkit/common_spec.rb
+++ b/spec/lib/sendgrid_toolkit/common_spec.rb
@@ -20,4 +20,13 @@ describe SendgridToolkit::Common do
     }.should_not raise_error
   end
 
+  # this will only really test it on a computer that's on on utc.
+  describe 'retrieve_with_timestamps' do
+    it 'should parse the created date in utc' do
+      FakeWeb.register_uri(:post, %r|https://sendgrid\.com/api/fakeclass\.get\.json\?.*date=1|, :body => '[{"created":"2013-11-25 13:00:00"}]')
+      fake_class = @fake_class.retrieve_with_timestamps
+      fake_class[0]['created'].utc.iso8601.should == "2013-11-25T13:00:00Z"
+    end
+  end
+
 end


### PR DESCRIPTION
Since our servers don't run on UTC-time (yes, I don't like it either), the dates from sendgrid are off by a few hours. 

Dates from sendgrid are always in utc, so they should be parsed as utc.
