### PR TITLE
updated to new (better) sendgrid api location

### DIFF
--- a/lib/sendgrid_toolkit.rb
+++ b/lib/sendgrid_toolkit.rb
@@ -16,7 +16,7 @@ require 'sendgrid_toolkit/newsletter/lists'
 require 'sendgrid_toolkit/newsletter/list_emails'
 
 module SendgridToolkit
-  BASE_URI = "sendgrid.com/api"
+  BASE_URI = "api.sendgrid.com/api"
   
   class << self
     def api_user=(v); @api_user = v; end


### PR DESCRIPTION
We (SendGrid) [recently opened up](http://support.sendgrid.com/hc/en-us/articles/200738596-New-Web-API-URL-api-sendgrid-com) `api.sendgrid.com/api/` as a new endpoint for our API.

It has a number of benefits over the old `sendgrid.com/api/`, including the possibility of faster connection times.
