### PR TITLE
Add support for advanced statistics

### DIFF
--- a/lib/sendgrid_toolkit/statistics.rb
+++ b/lib/sendgrid_toolkit/statistics.rb
@@ -1,11 +1,20 @@
 module SendgridToolkit
   class Statistics < AbstractSendgridClient
+    def advanced(data_type, start_date, options = {})
+      options.merge! :data_type => data_type
+      options.merge! :start_date => format_date(start_date, options)
+
+      response = api_post('stats', 'getAdvanced', options)
+      response.each { |r| r['date'] = Date.parse(r['date']) if r.kind_of?(Hash) && r.has_key?('date') }
+      response
+    end
+
     def retrieve(options = {})
       response = api_post('stats', 'get', options)
       response.each {|r| r['date'] = Date.parse(r['date']) if r.kind_of?(Hash) && r.has_key?('date')}
       response
     end
-    
+
     def retrieve_aggregate(options = {})
       options.merge! :aggregate => 1
       response = retrieve options
@@ -22,11 +31,28 @@ module SendgridToolkit
         resp[int_field] = resp[int_field].to_i if resp.has_key?(int_field)
       end
     end
- 
+
     def list_categories(options = {})
       options.merge! :list => true
       response = retrieve options
       response
+    end
+
+    private
+
+    def format_date(date, options = {})
+      if date.is_a? Date
+        case options[:aggregated_by].to_s
+        when 'week'
+          date = date.strftime("%Y-%V")
+        when 'month'
+          date = date.strftime("%Y-%m")
+        else
+          date = date.strftime("%Y-%m-%d")
+        end
+      end
+
+      date
     end
   end
 end

--- a/spec/lib/sendgrid_toolkit/statistics_spec.rb
+++ b/spec/lib/sendgrid_toolkit/statistics_spec.rb
@@ -48,4 +48,72 @@ describe SendgridToolkit::Statistics do
       cats[2]['category'].should == 'categoryC'
     end
   end
+
+  describe "#advanced" do
+    it "parses browser totals" do
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json\?.*data_type=browsers|, :body => '[{"date":"2014-01-21","delivered":{"Chrome":1},"request":{"Chrome":1},"processed":{"Chrome":1}},{"date":"2014-01-22","delivered":{"Chrome":1},"request":{"Chrome":1},"processed":{"Chrome":1}}]')
+      stats = @obj.advanced('browsers', Date.new)
+      stats.each do |stat|
+        %w(delivered processed request).each do |type|
+          stat[type].kind_of?(Hash).should == true if stat.has_key?(type)
+        end
+        stat['date'].kind_of?(Date).should == true
+      end
+    end
+
+    it "parses client totals" do
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json\?.*data_type=clients|, :body => '[{"date":"2014-01-21","delivered":{"Gmail":1},"request":{"Gmail":1},"processed":{"Gmail":1}},{"date":"2014-01-22","delivered":{"Gmail":1},"request":{"Gmail":1},"processed":{"Gmail":1}}]')
+      stats = @obj.advanced('clients', Date.new)
+      stats.each do |stat|
+        %w(delivered processed request).each do |type|
+          stat[type].kind_of?(Hash).should == true if stat.has_key?(type)
+        end
+        stat['date'].kind_of?(Date).should == true
+      end
+    end
+
+    it "parses device totals" do
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json\?.*data_type=device|, :body => '[{"date":"2014-01-21","delivered":{"Webmail":1},"request":{"Webmail":1},"processed":{"Webmail":1}},{"date":"2014-01-22","delivered":{"Webmail":1},"request":{"Webmail":1},"processed":{"Webmail":1}}]')
+      stats = @obj.advanced('devices', Date.new)
+      stats.each do |stat|
+        %w(delivered processed request).each do |type|
+          stat[type].kind_of?(Hash).should == true if stat.has_key?(type)
+        end
+        stat['date'].kind_of?(Date).should == true
+      end
+    end
+
+    it "parses geo totals" do
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json\?.*data_type=geo|, :body => '[{"date":"2014-01-21","delivered":{"US":1},"request":{"US":1},"processed":{"US":1}},{"date":"2014-01-22","delivered":{"US":1},"request":{"US":1},"processed":{"US":1}}]')
+      stats = @obj.advanced('geo', Date.new)
+      stats.each do |stat|
+        %w(delivered processed request).each do |type|
+          stat[type].kind_of?(Hash).should == true if stat.has_key?(type)
+        end
+        stat['date'].kind_of?(Date).should == true
+      end
+    end
+
+    it "parses global totals" do
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json\?.*data_type=global|, :body => '[{"delivered":41,"request":41,"unique_open":1,"unique_click":1,"processed":41,"date":"2013-01-01","open":2,"click":1},{"delivered":224,"unique_open":1,"request":224,"processed":224,"date":"2013-01-02","open":3}]')
+      stats = @obj.advanced('global', Date.new)
+      stats.each do |stat|
+        %w(click delivered open processed request unique_click unique_open).each do |type|
+          stat[type].kind_of?(Integer).should == true if stat.has_key?(type)
+        end
+        stat['date'].kind_of?(Date).should == true
+      end
+    end
+
+    it "parses ISP totals" do
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json\?.*data_type=isps|, :body => '[{"date":"2014-01-21","delivered":{"Gmail":1},"request":{"Gmail":1},"processed":{"Gmail":1}},{"date":"2014-01-22","delivered":{"Gmail":1},"request":{"Gmail":1},"processed":{"Gmail":1}}]')
+      stats = @obj.advanced('isps', Date.new)
+      stats.each do |stat|
+        %w(delivered processed request).each do |type|
+          stat[type].kind_of?(Hash).should == true if stat.has_key?(type)
+        end
+        stat['date'].kind_of?(Date).should == true
+      end
+    end
+  end
 end


### PR DESCRIPTION
SendGrid has some [advanced statistics](http://sendgrid.com/docs/API_Reference/Web_API/Statistics/statistics_advanced.html) that they allow you to pull from their Web API. This pull request adds support for the advanced statistics to the Statistics client.

It also has tests for parsing the JSON response fixtures I created based on the results of my own API calls. I didn't add any remote tests though, but can if you like.
