### PR TITLE
Submit data through POST body instead of query string params

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ In addition to unit tests, SendgridToolkit comes with a limited suite of "webcon
   1. Create a test account with SendGrid and store the credentials in `TEST_SMTP_USERNAME` and `TEST_SMTP_PASSWORD` environment variables. This is so that actions are performed on a test account and not your real SendGrid account. If you forget, don't worry -- the tests will fail but they will **not** fall back on the account that uses `SMTP_USERNAME` and `SMTP_PASSWORD`.
   2. Change "xit" it "it" on the tests you wish to run.
 
-Running "spec spec" out of the box will run the standard suite of tests (all network access is stubbed out).
+Running `rspec` out of the box will run the standard suite of tests (all network access is stubbed out).
 
 [1]: http://github.com/jamesBrennan
 [2]: http://sendgrid.com/docs/API_Reference/Web_API/

--- a/lib/sendgrid_toolkit/abstract_sendgrid_client.rb
+++ b/lib/sendgrid_toolkit/abstract_sendgrid_client.rb
@@ -13,8 +13,8 @@ module SendgridToolkit
 
     def api_post(module_name, action_name, opts = {})
       base_path = compose_base_path(module_name, action_name)
-      response = HTTParty.post("https://#{SendgridToolkit.base_uri}/#{base_path}.json?",
-                               :query => get_credentials.merge(opts),
+      response = HTTParty.post("https://#{SendgridToolkit.base_uri}/#{base_path}.json",
+                               :body => get_credentials.merge(opts),
                                :format => :json)
       if response.code > 401
         raise(SendgridToolkit::SendgridServerError, "The sengrid server returned an error. #{response.inspect}")

--- a/spec/lib/sendgrid_toolkit/abstract_sendgrid_client_spec.rb
+++ b/spec/lib/sendgrid_toolkit/abstract_sendgrid_client_spec.rb
@@ -10,21 +10,21 @@ describe SendgridToolkit::AbstractSendgridClient do
 
   describe "#api_post" do
     it "throws error when authentication fails" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/profile\.get\.json\?|, :body => '{"error":{"code":401,"message":"Permission denied, wrong credentials"}}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/profile\.get\.json|, :body => '{"error":{"code":401,"message":"Permission denied, wrong credentials"}}')
       @obj = SendgridToolkit::AbstractSendgridClient.new("fakeuser", "fakepass")
       lambda {
         @obj.send(:api_post, "profile", "get", {})
       }.should raise_error SendgridToolkit::AuthenticationFailed
     end
     it "thows error when sendgrid response is a server error" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/profile\.get\.json\?|, :body => '{}', :status => ['500', 'Internal Server Error'])
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/profile\.get\.json|, :body => '{}', :status => ['500', 'Internal Server Error'])
       @obj = SendgridToolkit::AbstractSendgridClient.new("someuser", "somepass")
       lambda {
         @obj.send(:api_post, "profile", "get", {})
       }.should raise_error SendgridToolkit::SendgridServerError
     end
     it "thows error when sendgrid response is an API error" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.get\.json\?|, :body => '{"error": "error in end_date: end date is in the future"}', :status => ['400', 'Bad Request'])
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.get\.json|, :body => '{"error": "error in end_date: end date is in the future"}', :status => ['400', 'Bad Request'])
       @obj = SendgridToolkit::AbstractSendgridClient.new("someuser", "somepass")
       lambda {
         @obj.send(:api_post, "stats", "get", {})
@@ -48,7 +48,7 @@ describe SendgridToolkit::AbstractSendgridClient do
     it "uses module level user and key if they are set" do
       SendgridToolkit.api_user = "username"
       SendgridToolkit.api_key = "apikey"
-      
+
       SendgridToolkit.api_key.should == "apikey"
       SendgridToolkit.api_user.should == "username"
 

--- a/spec/lib/sendgrid_toolkit/blocks_spec.rb
+++ b/spec/lib/sendgrid_toolkit/blocks_spec.rb
@@ -8,7 +8,7 @@ describe SendgridToolkit::Blocks do
 
   describe "#retrieve" do
     it "returns array of bounced emails" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/blocks\.get\.json\?|, :body => '[{"email":"email1@domain.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email1@domain.com"},{"email":"email2@domain2.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email2@domain2.com"}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/blocks\.get\.json|, :body => '[{"email":"email1@domain.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email1@domain.com"},{"email":"email2@domain2.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email2@domain2.com"}]')
       blocks = @obj.retrieve
       blocks[0]['email'].should == "email1@domain.com"
       blocks[0]['status'].should == "5.1.1"
@@ -18,7 +18,7 @@ describe SendgridToolkit::Blocks do
 
   describe "#retrieve_with_timestamps" do
     it "parses timestamps" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/blocks\.get\.json\?.*date=1|, :body => '[{"email":"email1@domain.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email1@domain.com","created":"2009-06-01 19:41:39"},{"email":"email2@domain2.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email2@domain2.com","created":"2009-06-12 19:41:39"}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/blocks\.get\.json|, :body => '[{"email":"email1@domain.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email1@domain.com","created":"2009-06-01 19:41:39"},{"email":"email2@domain2.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email2@domain2.com","created":"2009-06-12 19:41:39"}]')
       blocks = @obj.retrieve_with_timestamps
       0.upto(1) do |index|
         blocks[index]['created'].kind_of?(Time).should == true
@@ -30,19 +30,19 @@ describe SendgridToolkit::Blocks do
 
   describe "#delete" do
     it "raises no errors on success" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/blocks\.delete\.json\?.*email=.+|, :body => '{"message":"success"}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/blocks\.delete\.json|, :body => '{"message":"success"}')
       lambda {
         @obj.delete :email => "user@domain.com"
       }.should_not raise_error
     end
     it "raises error when email address does not exist" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/blocks\.delete\.json\?.*email=.+|, :body => '{"message":"Email does not exist"}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/blocks\.delete\.json|, :body => '{"message":"Email does not exist"}')
       lambda {
         @obj.delete :email => "user@domain.com"
       }.should raise_error SendgridToolkit::EmailDoesNotExist
     end
     it "does not choke if response does not have a 'message' field" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/blocks\.delete\.json\?.*email=.+|, :body => '{}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/blocks\.delete\.json|, :body => '{}')
       lambda {
         @obj.delete :email => "user@domain.com"
       }.should_not raise_error

--- a/spec/lib/sendgrid_toolkit/bounces_spec.rb
+++ b/spec/lib/sendgrid_toolkit/bounces_spec.rb
@@ -8,7 +8,7 @@ describe SendgridToolkit::Bounces do
 
   describe "#retrieve" do
     it "returns array of bounced emails" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/bounces\.get\.json\?|, :body => '[{"email":"email1@domain.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email1@domain.com"},{"email":"email2@domain2.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email2@domain2.com"}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/bounces\.get\.json|, :body => '[{"email":"email1@domain.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email1@domain.com"},{"email":"email2@domain2.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email2@domain2.com"}]')
       bounces = @obj.retrieve
       bounces[0]['email'].should == "email1@domain.com"
       bounces[0]['status'].should == "5.1.1"
@@ -18,7 +18,7 @@ describe SendgridToolkit::Bounces do
 
   describe "#retrieve_with_timestamps" do
     it "parses timestamps" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/bounces\.get\.json\?.*date=1|, :body => '[{"email":"email1@domain.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email1@domain.com","created":"2009-06-01 19:41:39"},{"email":"email2@domain2.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email2@domain2.com","created":"2009-06-12 19:41:39"}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/bounces\.get\.json|, :body => '[{"email":"email1@domain.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email1@domain.com","created":"2009-06-01 19:41:39"},{"email":"email2@domain2.com","status":"5.1.1","reason":"host [127.0.0.1] said: 550 5.1.1 unknown or illegal user: email2@domain2.com","created":"2009-06-12 19:41:39"}]')
       bounces = @obj.retrieve_with_timestamps
       0.upto(1) do |index|
         bounces[index]['created'].kind_of?(Time).should == true
@@ -30,19 +30,19 @@ describe SendgridToolkit::Bounces do
 
   describe "#delete" do
     it "raises no errors on success" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/bounces\.delete\.json\?.*email=.+|, :body => '{"message":"success"}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/bounces\.delete\.json|, :body => '{"message":"success"}')
       lambda {
         @obj.delete :email => "user@domain.com"
       }.should_not raise_error
     end
     it "raises error when email address does not exist" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/bounces\.delete\.json\?.*email=.+|, :body => '{"message":"Email does not exist"}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/bounces\.delete\.json|, :body => '{"message":"Email does not exist"}')
       lambda {
         @obj.delete :email => "user@domain.com"
       }.should raise_error SendgridToolkit::EmailDoesNotExist
     end
     it "does not choke if response does not have a 'message' field" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/bounces\.delete\.json\?.*email=.+|, :body => '{}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/bounces\.delete\.json|, :body => '{}')
       lambda {
         @obj.delete :email => "user@domain.com"
       }.should_not raise_error

--- a/spec/lib/sendgrid_toolkit/common_spec.rb
+++ b/spec/lib/sendgrid_toolkit/common_spec.rb
@@ -14,7 +14,7 @@ describe SendgridToolkit::Common do
   end
 
   it "does not choke if response does not have a 'message' field" do
-    FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/fakeclass\.delete\.json\?.*email=.+|, :body => '{}')
+    FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/fakeclass\.delete\.json|, :body => '{}')
     lambda {
       @fake_class.delete :email => "user@domain.com"
     }.should_not raise_error
@@ -23,7 +23,7 @@ describe SendgridToolkit::Common do
   # this will only really test it on a computer that's on on utc.
   describe 'retrieve_with_timestamps' do
     it 'should parse the created date in utc' do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/fakeclass\.get\.json\?.*date=1|, :body => '[{"created":"2013-11-25 13:00:00"}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/fakeclass\.get\.json|, :body => '[{"created":"2013-11-25 13:00:00"}]')
       fake_class = @fake_class.retrieve_with_timestamps
       fake_class[0]['created'].utc.iso8601.should == "2013-11-25T13:00:00Z"
     end

--- a/spec/lib/sendgrid_toolkit/invalid_emails_spec.rb
+++ b/spec/lib/sendgrid_toolkit/invalid_emails_spec.rb
@@ -8,7 +8,7 @@ describe SendgridToolkit::InvalidEmails do
 
   describe "#retrieve" do
     it "returns array of invalid emails" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/invalidemails\.get\.json\?|, :body => '[{"email":"isaac@hotmail.comm","reason":"Mail domain mentioned in email address is unknown"},{"email":"isaac@hotmail","reason":"Bad Syntax"},{"email":"isaac@example.com","reason":"Known bad domain"}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/invalidemails\.get\.json|, :body => '[{"email":"isaac@hotmail.comm","reason":"Mail domain mentioned in email address is unknown"},{"email":"isaac@hotmail","reason":"Bad Syntax"},{"email":"isaac@example.com","reason":"Known bad domain"}]')
       invalid_emails = @obj.retrieve
       invalid_emails[0]['email'].should == "isaac@hotmail.comm"
       invalid_emails[0]['reason'].should == "Mail domain mentioned in email address is unknown"
@@ -21,7 +21,7 @@ describe SendgridToolkit::InvalidEmails do
 
   describe "#retrieve_with_timestamps" do
     it "parses timestamps" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/invalidemails\.get\.json\?.*date=1|, :body => '[{"email":"isaac@hotmail.comm","reason":"Mail domain mentioned in email address is unknown","created":"2009-06-01 19:41:39"},{"email":"isaac@hotmail","reason":"Bad Syntax","created":"2009-06-12 19:41:39"},{"email":"isaac@example.com","reason":"Known bad domain","created":"2009-06-13 09:40:01"}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/invalidemails\.get\.json|, :body => '[{"email":"isaac@hotmail.comm","reason":"Mail domain mentioned in email address is unknown","created":"2009-06-01 19:41:39"},{"email":"isaac@hotmail","reason":"Bad Syntax","created":"2009-06-12 19:41:39"},{"email":"isaac@example.com","reason":"Known bad domain","created":"2009-06-13 09:40:01"}]')
       invalid_emails = @obj.retrieve_with_timestamps
       0.upto(2) do |index|
         invalid_emails[index]['created'].kind_of?(Time).should == true
@@ -34,13 +34,13 @@ describe SendgridToolkit::InvalidEmails do
 
   describe "#delete" do
     it "raises no errors on success" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/invalidemails\.delete\.json\?.*email=.+|, :body => '{"message":"success"}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/invalidemails\.delete\.json|, :body => '{"message":"success"}')
       lambda {
         @obj.delete :email => "user@domain.com"
       }.should_not raise_error
     end
     it "raises error when email address does not exist" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/invalidemails\.delete\.json\?.*email=.+|, :body => '{"message":"Email does not exist"}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/invalidemails\.delete\.json|, :body => '{"message":"Email does not exist"}')
       lambda {
         @obj.delete :email => "user@domain.com"
       }.should raise_error SendgridToolkit::EmailDoesNotExist

--- a/spec/lib/sendgrid_toolkit/mail_spec.rb
+++ b/spec/lib/sendgrid_toolkit/mail_spec.rb
@@ -5,13 +5,13 @@ describe SendgridToolkit::Mail do
     FakeWeb.clean_registry
     @obj = SendgridToolkit::Mail.new("fakeuser", "fakepass")
   end
-  
+
   describe "#send" do
     it "raises error when sendgrid returns an error" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/mail\.send\.json\?|, :body => '{"message": "error", "errors": ["Missing destination email"]}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/mail\.send\.json|, :body => '{"message": "error", "errors": ["Missing destination email"]}')
       lambda {
         response = @obj.send_mail :from => "testing@fiverr.com", :subject => "Subject", :text => "Text", "x-smtpapi" => {:category => "Testing", :to => ["elad@fiverr.com"]}
       }.should raise_error SendgridToolkit::SendEmailError
     end
-  end  
+  end
 end

--- a/spec/lib/sendgrid_toolkit/newsletter/newsletter_sendgrid_client_spec.rb
+++ b/spec/lib/sendgrid_toolkit/newsletter/newsletter_sendgrid_client_spec.rb
@@ -12,9 +12,10 @@ describe SendgridToolkit::NewsletterSendgridClient do
 
     it 'prepends newsletter to the base path' do
       opts = {a: 1}
+      response = { 'message' => 'success' }
 
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/newsletter/lists/add\.json\?.*a=1|,
-                                  :body => '{"message":"success"}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/newsletter/lists/add\.json|,
+                                  :body => response.to_json)
 
       sendgrid_client = SendgridToolkit::NewsletterSendgridClient.new("fakeuser", "fakepass")
 

--- a/spec/lib/sendgrid_toolkit/spam_reports_spec.rb
+++ b/spec/lib/sendgrid_toolkit/spam_reports_spec.rb
@@ -8,7 +8,7 @@ describe SendgridToolkit::SpamReports do
 
   describe "#retrieve" do
     it "returns array of bounced emails" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/spamreports\.get\.json\?|, :body => '[{"email":"email1@domain.com"},{"email":"email2@domain2.com"}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/spamreports\.get\.json|, :body => '[{"email":"email1@domain.com"},{"email":"email2@domain2.com"}]')
       bounces = @obj.retrieve
       bounces[0]['email'].should == "email1@domain.com"
       bounces[1]['email'].should == "email2@domain2.com"
@@ -17,7 +17,7 @@ describe SendgridToolkit::SpamReports do
 
   describe "#retrieve_with_timestamps" do
     it "parses timestamps" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/spamreports\.get\.json\?.*date=1|, :body => '[{"email":"email1@domain.com","created":"2009-06-01 19:41:39"},{"email":"email2@domain2.com","created":"2009-06-12 19:41:39"}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/spamreports\.get\.json|, :body => '[{"email":"email1@domain.com","created":"2009-06-01 19:41:39"},{"email":"email2@domain2.com","created":"2009-06-12 19:41:39"}]')
       bounces = @obj.retrieve_with_timestamps
       0.upto(1) do |index|
         bounces[index]['created'].kind_of?(Time).should == true
@@ -29,13 +29,13 @@ describe SendgridToolkit::SpamReports do
 
   describe "#delete" do
     it "raises no errors on success" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/spamreports\.delete\.json\?.*email=.+|, :body => '{"message":"success"}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/spamreports\.delete\.json|, :body => '{"message":"success"}')
       lambda {
         @obj.delete :email => "user@domain.com"
       }.should_not raise_error
     end
     it "raises error when email address does not exist" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/spamreports\.delete\.json\?.*email=.+|, :body => '{"message":"Email does not exist"}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/spamreports\.delete\.json|, :body => '{"message":"Email does not exist"}')
       lambda {
         @obj.delete :email => "user@domain.com"
       }.should raise_error SendgridToolkit::EmailDoesNotExist

--- a/spec/lib/sendgrid_toolkit/statistics_spec.rb
+++ b/spec/lib/sendgrid_toolkit/statistics_spec.rb
@@ -5,10 +5,10 @@ describe SendgridToolkit::Statistics do
     FakeWeb.clean_registry
     @obj = SendgridToolkit::Statistics.new("fakeuser", "fakepass")
   end
-  
+
   describe "#retrieve" do
     it "parses daily totals" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.get\.json\?|, :body => '[{"date":"2009-06-20","requests":12342,"bounces":12,"clicks":10223,"opens":9992,"spamreports":5},{"date":"2009-06-21","requests":32342,"bounces":10,"clicks":14323,"opens":10995,"spamreports":7},{"date":"2009-06-22","requests":52342,"bounces":11,"clicks":19223,"opens":12992,"spamreports":2}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.get\.json|, :body => '[{"date":"2009-06-20","requests":12342,"bounces":12,"clicks":10223,"opens":9992,"spamreports":5},{"date":"2009-06-21","requests":32342,"bounces":10,"clicks":14323,"opens":10995,"spamreports":7},{"date":"2009-06-22","requests":52342,"bounces":11,"clicks":19223,"opens":12992,"spamreports":2}]')
       stats = @obj.retrieve
       stats.each do |stat|
         %w(bounces clicks delivered invalid_email opens repeat_bounces repeat_spamreports repeat_unsubscribes requests spamreports unsubscribes).each do |int|
@@ -18,18 +18,18 @@ describe SendgridToolkit::Statistics do
       end
     end
   end
-  
+
   describe "#retrieve_aggregate" do
     it "parses aggregate statistics" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.get\.json\?.*aggregate=1|, :body => '{"requests":12342,"bounces":12,"clicks":10223,"opens":9992,"spamreports":5}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.get\.json|, :body => '{"requests":12342,"bounces":12,"clicks":10223,"opens":9992,"spamreports":5}')
       stats = @obj.retrieve_aggregate
       %w(bounces clicks delivered invalid_email opens repeat_bounces repeat_spamreports repeat_unsubscribes requests spamreports unsubscribes).each do |int|
         stats[int].kind_of?(Integer).should == true if stats.has_key?(int) # We support all fields presently returned, but we are only testing what sendgrid officially documents
       end
     end
-    
+
     it "parses aggregate statistics for array response" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.get\.json\?.*aggregate=1|, :body => '[{"requests":12342,"bounces":12,"clicks":10223,"opens":9992,"spamreports":5},{"requests":5,"bounces":10,"clicks":10223,"opens":9992,"spamreports":5}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.get\.json|, :body => '[{"requests":12342,"bounces":12,"clicks":10223,"opens":9992,"spamreports":5},{"requests":5,"bounces":10,"clicks":10223,"opens":9992,"spamreports":5}]')
       stats = @obj.retrieve_aggregate
       %w(bounces clicks delivered invalid_email opens repeat_bounces repeat_spamreports repeat_unsubscribes requests spamreports unsubscribes).each do |int|
         # We support all fields presently returned, but we are only testing what sendgrid officially documents
@@ -38,10 +38,10 @@ describe SendgridToolkit::Statistics do
       end
     end
   end
-  
+
   describe "#list_categories" do
     it "parses categories list" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.get\.json\?.*list=true|, :body => '[{"category":"categoryA"},{"category":"categoryB"},{"category":"categoryC"}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.get\.json|, :body => '[{"category":"categoryA"},{"category":"categoryB"},{"category":"categoryC"}]')
       cats = @obj.list_categories
       cats[0]['category'].should == 'categoryA'
       cats[1]['category'].should == 'categoryB'
@@ -51,7 +51,7 @@ describe SendgridToolkit::Statistics do
 
   describe "#advanced" do
     it "parses browser totals" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json\?.*data_type=browsers|, :body => '[{"date":"2014-01-21","delivered":{"Chrome":1},"request":{"Chrome":1},"processed":{"Chrome":1}},{"date":"2014-01-22","delivered":{"Chrome":1},"request":{"Chrome":1},"processed":{"Chrome":1}}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json|, :body => '[{"date":"2014-01-21","delivered":{"Chrome":1},"request":{"Chrome":1},"processed":{"Chrome":1}},{"date":"2014-01-22","delivered":{"Chrome":1},"request":{"Chrome":1},"processed":{"Chrome":1}}]')
       stats = @obj.advanced('browsers', Date.new)
       stats.each do |stat|
         %w(delivered processed request).each do |type|
@@ -62,7 +62,7 @@ describe SendgridToolkit::Statistics do
     end
 
     it "parses client totals" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json\?.*data_type=clients|, :body => '[{"date":"2014-01-21","delivered":{"Gmail":1},"request":{"Gmail":1},"processed":{"Gmail":1}},{"date":"2014-01-22","delivered":{"Gmail":1},"request":{"Gmail":1},"processed":{"Gmail":1}}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json|, :body => '[{"date":"2014-01-21","delivered":{"Gmail":1},"request":{"Gmail":1},"processed":{"Gmail":1}},{"date":"2014-01-22","delivered":{"Gmail":1},"request":{"Gmail":1},"processed":{"Gmail":1}}]')
       stats = @obj.advanced('clients', Date.new)
       stats.each do |stat|
         %w(delivered processed request).each do |type|
@@ -73,7 +73,7 @@ describe SendgridToolkit::Statistics do
     end
 
     it "parses device totals" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json\?.*data_type=device|, :body => '[{"date":"2014-01-21","delivered":{"Webmail":1},"request":{"Webmail":1},"processed":{"Webmail":1}},{"date":"2014-01-22","delivered":{"Webmail":1},"request":{"Webmail":1},"processed":{"Webmail":1}}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json|, :body => '[{"date":"2014-01-21","delivered":{"Webmail":1},"request":{"Webmail":1},"processed":{"Webmail":1}},{"date":"2014-01-22","delivered":{"Webmail":1},"request":{"Webmail":1},"processed":{"Webmail":1}}]')
       stats = @obj.advanced('devices', Date.new)
       stats.each do |stat|
         %w(delivered processed request).each do |type|
@@ -84,7 +84,7 @@ describe SendgridToolkit::Statistics do
     end
 
     it "parses geo totals" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json\?.*data_type=geo|, :body => '[{"date":"2014-01-21","delivered":{"US":1},"request":{"US":1},"processed":{"US":1}},{"date":"2014-01-22","delivered":{"US":1},"request":{"US":1},"processed":{"US":1}}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json|, :body => '[{"date":"2014-01-21","delivered":{"US":1},"request":{"US":1},"processed":{"US":1}},{"date":"2014-01-22","delivered":{"US":1},"request":{"US":1},"processed":{"US":1}}]')
       stats = @obj.advanced('geo', Date.new)
       stats.each do |stat|
         %w(delivered processed request).each do |type|
@@ -95,7 +95,7 @@ describe SendgridToolkit::Statistics do
     end
 
     it "parses global totals" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json\?.*data_type=global|, :body => '[{"delivered":41,"request":41,"unique_open":1,"unique_click":1,"processed":41,"date":"2013-01-01","open":2,"click":1},{"delivered":224,"unique_open":1,"request":224,"processed":224,"date":"2013-01-02","open":3}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json|, :body => '[{"delivered":41,"request":41,"unique_open":1,"unique_click":1,"processed":41,"date":"2013-01-01","open":2,"click":1},{"delivered":224,"unique_open":1,"request":224,"processed":224,"date":"2013-01-02","open":3}]')
       stats = @obj.advanced('global', Date.new)
       stats.each do |stat|
         %w(click delivered open processed request unique_click unique_open).each do |type|
@@ -106,7 +106,7 @@ describe SendgridToolkit::Statistics do
     end
 
     it "parses ISP totals" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json\?.*data_type=isps|, :body => '[{"date":"2014-01-21","delivered":{"Gmail":1},"request":{"Gmail":1},"processed":{"Gmail":1}},{"date":"2014-01-22","delivered":{"Gmail":1},"request":{"Gmail":1},"processed":{"Gmail":1}}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.getAdvanced\.json|, :body => '[{"date":"2014-01-21","delivered":{"Gmail":1},"request":{"Gmail":1},"processed":{"Gmail":1}},{"date":"2014-01-22","delivered":{"Gmail":1},"request":{"Gmail":1},"processed":{"Gmail":1}}]')
       stats = @obj.advanced('isps', Date.new)
       stats.each do |stat|
         %w(delivered processed request).each do |type|

--- a/spec/lib/sendgrid_toolkit/unsubscribes_spec.rb
+++ b/spec/lib/sendgrid_toolkit/unsubscribes_spec.rb
@@ -5,10 +5,10 @@ describe SendgridToolkit::Unsubscribes do
     FakeWeb.clean_registry
     @obj = SendgridToolkit::Unsubscribes.new("fakeuser", "fakepass")
   end
-  
+
   describe "#retrieve" do
     it "returns array of unsubscribed email addresses" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/unsubscribes\.get\.json\?|, :body => '[{"email":"user@domain.com"},{"email":"user2@domain2.com"},{"email":"user3@domain2.com"}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/unsubscribes\.get\.json|, :body => '[{"email":"user@domain.com"},{"email":"user2@domain2.com"},{"email":"user3@domain2.com"}]')
       emails = @obj.retrieve
       emails[0]['email'].should == "user@domain.com"
       emails[1]['email'].should == "user2@domain2.com"
@@ -17,7 +17,7 @@ describe SendgridToolkit::Unsubscribes do
   end
   describe "#retrieve_with_timestamps" do
     it "parses timestamps" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/unsubscribes\.get\.json\?.*date=1|, :body => '[{"email":"user@domain.com","created":"2010-03-03 11:00:00"},{"email":"user2@domain2.com","created":"2010-03-04 21:00:00"},{"email":"user3@domain2.com","created":"2010-03-05 23:00:00"}]')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/unsubscribes\.get\.json|, :body => '[{"email":"user@domain.com","created":"2010-03-03 11:00:00"},{"email":"user2@domain2.com","created":"2010-03-04 21:00:00"},{"email":"user3@domain2.com","created":"2010-03-05 23:00:00"}]')
       emails = @obj.retrieve_with_timestamps
       0.upto(2) do |index|
         emails[index]['created'].kind_of?(Time).should == true
@@ -27,31 +27,31 @@ describe SendgridToolkit::Unsubscribes do
       emails[2]['created'].asctime.should == "Fri Mar  5 23:00:00 2010"
     end
   end
-  
+
   describe "#add" do
     it "raises no errors on success" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/unsubscribes\.add\.json\?.*email=.+|, :body => '{"message":"success"}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/unsubscribes\.add\.json|, :body => '{"message":"success"}')
       lambda {
         @obj.add :email => "user@domain.com"
       }.should_not raise_error
     end
     it "raises error when email already exists" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/unsubscribes\.add\.json\?.*email=.+|, :body => '{"message":"Unsubscribe email address already exists"}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/unsubscribes\.add\.json|, :body => '{"message":"Unsubscribe email address already exists"}')
       lambda {
         @obj.add :email => "user@domain.com"
       }.should raise_error SendgridToolkit::UnsubscribeEmailAlreadyExists
     end
   end
-  
+
   describe "#delete" do
     it "raises no errors on success" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/unsubscribes\.delete\.json\?.*email=.+|, :body => '{"message":"success"}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/unsubscribes\.delete\.json|, :body => '{"message":"success"}')
       lambda {
         @obj.delete :email => "user@domain.com"
       }.should_not raise_error
     end
     it "raises error when email address does not exist" do
-      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/unsubscribes\.delete\.json\?.*email=.+|, :body => '{"message":"Email does not exist"}')
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/unsubscribes\.delete\.json|, :body => '{"message":"Email does not exist"}')
       lambda {
         @obj.delete :email => "user@domain.com"
       }.should raise_error SendgridToolkit::UnsubscribeEmailDoesNotExist


### PR DESCRIPTION
Addresses #13 

I updated the `HTTParty.post` to use the `:body` parameter instead of `:query`. Submitting data through the POST `:body` allows us to get around data-length limitations associated with using `:query` string parameters.

Sendgrid Article: [HTTP POSTing The Right Way](https://sendgrid.zendesk.com/hc/en-us/articles/200181828-HTTP-POSTing-The-Right-Way)

I also updated the tests to support this change. Unfortunately [WebMock](https://github.com/chrisk/fakeweb#known-issues) doesn't allow to specific request bodies.