### PR TITLE
Add list_emails/count API call to retrieve subscriber count for list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ list_emails_obj = SendgridToolkit::ListEmails.new(api_user, api_key)
 ```
 - - -
 
+Count emails:
+```ruby
+count_hash = list_emails_obj.count :list => 'some_list_name'
+```
+`count` will be a hash, with one element whose key is 'count' and value is the number of subscribers on the specified list.
+
+- - -
+
 Get emails:
 ```ruby
 list_emails = list_emails_obj.get :list => 'some_list_name'

--- a/lib/sendgrid_toolkit/newsletter/list_emails.rb
+++ b/lib/sendgrid_toolkit/newsletter/list_emails.rb
@@ -24,6 +24,10 @@ module SendgridToolkit
       api_post('email', 'delete', options).parsed_response
     end
 
+    def count(options = {})
+      api_post('email', 'count', options).parsed_response
+    end
+
     protected
 
     def compose_base_path(module_name, action_name)


### PR DESCRIPTION
Sendgrid just recently added an API call to get the subscriber count for a given list. See: 

https://community.sendgrid.com/sendgrid/topics/api_lists_email_get_on_large_list_returns_an_internal_error?rfm=1

This PR adds support for that new API call.

Thanks!