### PR TITLE
Have Common#retrieve_with_timestamps support HTTParty::Response objects…

### DIFF
--- a/lib/sendgrid_toolkit/common.rb
+++ b/lib/sendgrid_toolkit/common.rb
@@ -10,7 +10,10 @@ module SendgridToolkit
     def retrieve_with_timestamps(options = {})
       options.merge! :date => 1
       response = retrieve options
-      if response.is_a? Array
+      if response.is_a? HTTParty::Response
+        response = response.parsed_response
+      end
+      if response.is_a?(Array)
         response.each do |message|
           parse_message_time message
         end


### PR DESCRIPTION
…since that is what HTTParty returns as of 0.13.x